### PR TITLE
FEW-BRAND-01: manter apenas logo; remover cores e ajustar i18n

### DIFF
--- a/salonix-frontend-web/src/App.jsx
+++ b/salonix-frontend-web/src/App.jsx
@@ -55,35 +55,6 @@ function TenantThemeManager() {
 
     const effectiveTheme = { ...targetTheme };
     
-    // Aplicar cores personalizadas do tenant
-    if (targetBranding?.primaryColor) {
-      effectiveTheme.primary = targetBranding.primaryColor;
-      effectiveTheme.accent = targetBranding.primaryColor;
-      effectiveTheme.border = targetBranding.primaryColor;
-    }
-    
-    if (targetBranding?.secondaryColor) {
-      effectiveTheme.secondary = targetBranding.secondaryColor;
-      effectiveTheme.surfaceForeground = targetBranding.secondaryColor;
-    }
-    
-    // Aplicar cores de destaque personalizadas
-    if (targetBranding?.highlightColor) {
-      effectiveTheme.highlight = targetBranding.highlightColor;
-    }
-    
-    // Aplicar cores de superfície personalizadas
-    if (targetBranding?.surfaceColor) {
-      effectiveTheme.surface = targetBranding.surfaceColor;
-    }
-    
-    // Aplicar cores de texto personalizadas
-    if (targetBranding?.textColor) {
-      effectiveTheme.primaryForeground = targetBranding.textColor;
-      effectiveTheme.secondaryForeground = targetBranding.textColor;
-      effectiveTheme.highlightForeground = targetBranding.textColor;
-    }
-    
     // Garantir que as cores de texto sejam adequadas para o tema atual
     const isDarkTheme = root.classList.contains('theme-dark');
     if (isDarkTheme) {

--- a/salonix-frontend-web/src/api/tenant.js
+++ b/salonix-frontend-web/src/api/tenant.js
@@ -15,15 +15,11 @@ export function fetchTenantMeta(slug, config = {}) {
 }
 
 export async function updateTenantBranding({
-  primaryColor,
-  secondaryColor,
   logoFile,
   logoUrl,
 }) {
   if (logoFile instanceof File) {
     const formData = new FormData();
-    if (primaryColor) formData.append('primary_color', primaryColor);
-    if (secondaryColor) formData.append('secondary_color', secondaryColor);
     formData.append('logo', logoFile);
     if (logoUrl && /^https?:\/\//i.test(logoUrl.trim())) {
       formData.append('logo_url', logoUrl.trim());
@@ -36,8 +32,6 @@ export async function updateTenantBranding({
   }
 
   const payload = {};
-  if (primaryColor) payload.primary_color = primaryColor;
-  if (secondaryColor) payload.secondary_color = secondaryColor;
   if (logoUrl && /^https?:\/\//i.test(logoUrl.trim())) {
     payload.logo_url = logoUrl.trim();
   }

--- a/salonix-frontend-web/src/contexts/ThemeContext.jsx
+++ b/salonix-frontend-web/src/contexts/ThemeContext.jsx
@@ -1,6 +1,5 @@
-import React, { createContext, useEffect, useState, useCallback } from 'react';
+import { createContext, useEffect, useState, useCallback } from 'react';
 import { useAuth } from '../hooks/useAuth';
-import { useTenant } from '../hooks/useTenant';
 import client from '../api/client';
 import { THEMES, getSystemTheme, resolveTheme } from '../constants/themes';
 
@@ -10,48 +9,31 @@ const ThemeContext = createContext();
 // Provider do contexto de tema
 export const ThemeProvider = ({ children }) => {
   const { user, isAuthenticated } = useAuth();
-  const { branding } = useTenant();
   const [theme, setTheme] = useState(THEMES.SYSTEM);
   const [resolvedTheme, setResolvedTheme] = useState(THEMES.LIGHT);
   const [isLoading, setIsLoading] = useState(true);
 
   // Aplica tema no DOM
-  const applyTheme = useCallback(
-    (theme) => {
-      const root = document.documentElement;
-      const body = document.body;
-      
-      // Remove classes antigas
-      body.removeAttribute('data-theme');
-      root.classList.remove('theme-light', 'theme-dark');
-      
-      // Aplica novo tema usando data-theme
-      body.setAttribute('data-theme', theme);
-      
-      // Aplica branding personalizado se disponível
-      if (branding) {
-        if (branding.primaryColor) {
-          root.style.setProperty('--accent-primary', branding.primaryColor);
-        }
-        if (branding.backgroundColor) {
-          root.style.setProperty('--bg-primary', branding.backgroundColor);
-        }
-        if (branding.textColor) {
-          root.style.setProperty('--text-primary', branding.textColor);
-        }
-      }
+  const applyTheme = useCallback((theme) => {
+    const root = document.documentElement;
+    const body = document.body;
 
-      // Atualiza meta theme-color para mobile
-      const metaThemeColor = document.querySelector('meta[name="theme-color"]');
-      if (metaThemeColor) {
-        const themeColor =
-          branding?.primaryColor ||
-          (theme === THEMES.DARK ? '#0f172a' : '#ffffff');
-        metaThemeColor.setAttribute('content', themeColor);
-      }
-    },
-    [branding]
-  );
+    // Remove classes antigas
+    body.removeAttribute('data-theme');
+    root.classList.remove('theme-light', 'theme-dark');
+
+    // Aplica novo tema usando data-theme
+    body.setAttribute('data-theme', theme);
+
+    // Paleta fixa do tema: sem aplicação de cores de branding (FEW-BRAND-01)
+
+    // Atualiza meta theme-color para mobile
+    const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+    if (metaThemeColor) {
+      const themeColor = theme === THEMES.DARK ? '#0f172a' : '#ffffff';
+      metaThemeColor.setAttribute('content', themeColor);
+    }
+  }, []);
 
   // Carrega tema do usuário autenticado
   const loadUserTheme = useCallback(async () => {
@@ -161,7 +143,7 @@ export const ThemeProvider = ({ children }) => {
     if (resolvedTheme) {
       applyTheme(resolvedTheme);
     }
-  }, [branding, resolvedTheme, applyTheme]);
+  }, [resolvedTheme, applyTheme]);
 
   // Inicialização do tema
   useEffect(() => {

--- a/salonix-frontend-web/src/i18n/locales/en.json
+++ b/salonix-frontend-web/src/i18n/locales/en.json
@@ -219,9 +219,9 @@
   "settings": {
     "title": "Settings",
     "subtitle": "Manage your business settings",
-    "tabs": {
+  "tabs": {
       "general": "General",
-      "branding": "Branding",
+      "branding": "Logo",
       "notifications": "Notifications",
       "business": "Business"
     },
@@ -263,7 +263,7 @@
       "no_logo": "No logo defined.",
       "preview_alt": "Logo preview",
       "logo_file": "Logo file",
-      "saved": "Branding updated successfully."
+      "saved": "Logo updated successfully."
     }
   },
   "customers": {

--- a/salonix-frontend-web/src/i18n/locales/pt.json
+++ b/salonix-frontend-web/src/i18n/locales/pt.json
@@ -225,9 +225,9 @@
   "settings": {
     "title": "Configurações",
     "subtitle": "Gerencie as configurações do seu negócio",
-    "tabs": {
+  "tabs": {
       "general": "Geral",
-      "branding": "Branding",
+      "branding": "Logo",
       "notifications": "Notificações",
       "business": "Negócio"
     },
@@ -280,7 +280,7 @@
       "no_logo": "Nenhum logo definido.",
       "preview_alt": "Pré-visualização do logo",
       "logo_file": "Arquivo de logo",
-      "saved": "Branding atualizado com sucesso."
+      "saved": "Logo atualizado com sucesso."
     }
   },
   "customers": {

--- a/salonix-frontend-web/src/pages/Settings.jsx
+++ b/salonix-frontend-web/src/pages/Settings.jsx
@@ -26,7 +26,7 @@ import {
 } from '../utils/tenantPlan';
 
 const TAB_ITEMS = [
-  { id: 'branding', label: 'settings.tabs.branding', icon: '🎨' },
+  { id: 'branding', label: 'settings.tabs.branding', icon: '🖼️' },
   { id: 'general', label: 'settings.tabs.general', icon: '⚙️' },
   { id: 'notifications', label: 'settings.tabs.notifications', icon: '🔔' },
   { id: 'business', label: 'settings.tabs.business', icon: '🏢' },
@@ -107,12 +107,10 @@ function buildInitialSettings(profile, channels, branding) {
         DEFAULT_TENANT_META.profile.appointmentDuration,
       bufferTime:
         safeProfile.bufferTime ?? DEFAULT_TENANT_META.profile.bufferTime,
-    },
-    branding: {
-      primaryColor: safeBranding.primaryColor || '#6B7280',
-      secondaryColor: safeBranding.secondaryColor || '#1F2937',
+  },
+  branding: {
       logoUrl: safeBranding.logoUrl || '',
-    },
+  },
   };
 }
 
@@ -383,8 +381,6 @@ function Settings() {
 
     try {
       await updateTenantBranding({
-        primaryColor: settings.branding.primaryColor,
-        secondaryColor: settings.branding.secondaryColor,
         logoFile: brandingFile,
         logoUrl: brandingFile ? undefined : settings.branding.logoUrl,
       });
@@ -408,8 +404,6 @@ function Settings() {
     brandingFile,
     refreshTenantData,
     settings.branding.logoUrl,
-    settings.branding.primaryColor,
-    settings.branding.secondaryColor,
     t,
   ]);
 
@@ -569,81 +563,7 @@ function Settings() {
 
   const renderBrandingSettings = () => (
     <div className="space-y-6">
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div>
-          <label className="mb-1 block text-sm font-medium text-brand-surfaceForeground">
-            {t('settings.branding.primary_color', 'Cor primária')}
-          </label>
-          <div className="flex items-center gap-3">
-            <input
-              type="color"
-              value={settings.branding.primaryColor}
-              onChange={(e) =>
-                setSettings({
-                  ...settings,
-                  branding: { ...settings.branding, primaryColor: e.target.value },
-                })
-              }
-              disabled={tenantLoading}
-              className="h-10 w-16 cursor-pointer"
-            />
-            <input
-              type="text"
-              value={settings.branding.primaryColor}
-              onChange={(e) =>
-                setSettings({
-                  ...settings,
-                  branding: { ...settings.branding, primaryColor: e.target.value },
-                })
-              }
-              disabled={tenantLoading}
-              className="flex-1 rounded-lg border border-brand-border bg-brand-surface px-3 py-2 text-brand-surfaceForeground focus:outline-none focus:ring-2 focus:ring-brand-primary"
-              style={{
-                backgroundColor: 'var(--bg-primary)',
-                color: 'var(--text-primary)',
-                borderColor: 'var(--border-primary)'
-              }}
-            />
-          </div>
-        </div>
-
-        <div>
-          <label className="mb-1 block text-sm font-medium text-brand-surfaceForeground">
-            {t('settings.branding.secondary_color', 'Cor secundária')}
-          </label>
-          <div className="flex items-center gap-3">
-            <input
-              type="color"
-              value={settings.branding.secondaryColor}
-              onChange={(e) =>
-                setSettings({
-                  ...settings,
-                  branding: { ...settings.branding, secondaryColor: e.target.value },
-                })
-              }
-              disabled={tenantLoading}
-              className="h-10 w-16 cursor-pointer"
-            />
-            <input
-              type="text"
-              value={settings.branding.secondaryColor}
-              onChange={(e) =>
-                setSettings({
-                  ...settings,
-                  branding: { ...settings.branding, secondaryColor: e.target.value },
-                })
-              }
-              disabled={tenantLoading}
-              className="flex-1 rounded-lg border border-brand-border bg-brand-surface px-3 py-2 text-brand-surfaceForeground focus:outline-none focus:ring-2 focus:ring-brand-primary"
-              style={{
-                backgroundColor: 'var(--bg-primary)',
-                color: 'var(--text-primary)',
-                borderColor: 'var(--border-primary)'
-              }}
-            />
-          </div>
-        </div>
-      </div>
+      {/* Campos de cor removidos (FEW-BRAND-01) */}
 
       <div className="space-y-3">
         <label className="block text-sm font-medium text-brand-surfaceForeground">

--- a/salonix-frontend-web/src/utils/tenant.js
+++ b/salonix-frontend-web/src/utils/tenant.js
@@ -62,12 +62,8 @@ export const DEFAULT_TENANT_META = {
     appleTouchIconUrl: null,
     appName: 'TimelyOne',
     shortName: 'Timely',
-    themeColor: '#6B7280',
-    backgroundColor: '#FFFFFF',
     splashScreens: [],
     icons: [],
-    primaryColor: '#6B7280',
-    secondaryColor: '#1F2937',
   },
   flags: {
     enableCustomerPwa: false,
@@ -294,11 +290,6 @@ function normalizeBranding(brandingBlock, rawMeta, fallback) {
     favicon_url: rawMeta?.favicon_url ?? brandingBlock?.favicon_url ?? brandingBlock?.faviconUrl,
     apple_touch_icon_url:
       rawMeta?.apple_touch_icon_url ?? brandingBlock?.apple_touch_icon_url ?? brandingBlock?.appleTouchIconUrl,
-    primary_color: rawMeta?.primary_color ?? brandingBlock?.primary_color ?? brandingBlock?.primaryColor,
-    secondary_color: rawMeta?.secondary_color ?? brandingBlock?.secondary_color ?? brandingBlock?.secondaryColor,
-    theme_color: rawMeta?.theme_color ?? brandingBlock?.theme_color ?? brandingBlock?.themeColor,
-    background_color:
-      rawMeta?.background_color ?? brandingBlock?.background_color ?? brandingBlock?.backgroundColor,
     app_name: rawMeta?.app_name ?? brandingBlock?.app_name ?? brandingBlock?.appName,
     short_name: rawMeta?.short_name ?? brandingBlock?.short_name ?? brandingBlock?.shortName,
     splash_screens: rawMeta?.splash_screens ?? brandingBlock?.splash_screens ?? brandingBlock?.splashScreens,
@@ -317,18 +308,6 @@ function normalizeBranding(brandingBlock, rawMeta, fallback) {
   }
   if (brandingSource.apple_touch_icon_url !== undefined) {
     result.appleTouchIconUrl = brandingSource.apple_touch_icon_url || null;
-  }
-  if (brandingSource.primary_color) {
-    result.primaryColor = brandingSource.primary_color;
-  }
-  if (brandingSource.secondary_color) {
-    result.secondaryColor = brandingSource.secondary_color;
-  }
-  if (brandingSource.theme_color) {
-    result.themeColor = brandingSource.theme_color;
-  }
-  if (brandingSource.background_color) {
-    result.backgroundColor = brandingSource.background_color;
   }
   if (brandingSource.app_name) {
     result.appName = brandingSource.app_name;


### PR DESCRIPTION
- Renomeia aba “Branding” para “Logo” (🖼️) em Settings
- Atualiza i18n: tabs e “settings.branding.saved” → “Logo atualizado…”
- Remove aplicação de cores em App.jsx e ThemeContext.jsx
- Limpa utils/tenant.js (remove cores de DEFAULT_TENANT_META e normalizeBranding)
- Ajusta Settings.jsx para salvar apenas logo (arquivo/URL)