### PR TITLE
FEW-246: Documentar CaptchaGate, envs e modos

### DIFF
--- a/salonix-frontend-web/.env.example
+++ b/salonix-frontend-web/.env.example
@@ -2,3 +2,14 @@ VITE_API_URL=http://localhost:8000/api/
 # Opcional em dev: bypass do captcha para login/registro/reset
 # Envie também no backend como CAPTCHA_BYPASS_TOKEN
 VITE_CAPTCHA_BYPASS_TOKEN=dev-bypass
+
+# Captcha Provider (turnstile | hcaptcha | ou vazio para dev-checkbox)
+VITE_CAPTCHA_PROVIDER=turnstile
+
+# Cloudflare Turnstile Site Key (se provider=turnstile)
+# Use chaves de teste oficiais: 1x00000000000000000000AA (pass), 2x00000000000000000000AB (block)
+VITE_TURNSTILE_SITEKEY=1x00000000000000000000AA
+
+# hCaptcha Site Key (se provider=hcaptcha)
+# Use chaves de teste oficiais: 10000000-ffff-ffff-ffff-000000000001
+VITE_HCAPTCHA_SITEKEY=10000000-ffff-ffff-ffff-000000000001

--- a/salonix-frontend-web/README.md
+++ b/salonix-frontend-web/README.md
@@ -191,6 +191,8 @@ VITE_CAPTCHA_BYPASS_TOKEN=dev-bypass
 # VITE_HCAPTCHA_SITEKEY=...   # se usar hcaptcha
 ```
 
+Para detalhes de segurança e configuração de captcha, consulte [docs/SECURITY_NOTES.md](docs/SECURITY_NOTES.md).
+
 ### Staging
 ```env
 VITE_API_URL=https://api-staging.salonix.com

--- a/salonix-frontend-web/docs/SECURITY_NOTES.md
+++ b/salonix-frontend-web/docs/SECURITY_NOTES.md
@@ -16,8 +16,26 @@
 - Plan feature flags (push, reports) consumed via `/api/tenant/meta`.
 - Feedback visibility is owner-only on the frontend; backend may keep `feedback_enabled` for future use, but FE does not gate by it.
 
+## Captcha Configuration
+The application supports pluggable captcha providers via `src/components/security/CaptchaGate.jsx`.
+
+### Environment Variables
+Configure in `.env`:
+- `VITE_CAPTCHA_PROVIDER`: `turnstile` (recommended), `hcaptcha`, or empty (dev fallback).
+- `VITE_TURNSTILE_SITEKEY`: Your Cloudflare site key.
+- `VITE_HCAPTCHA_SITEKEY`: Your hCaptcha site key.
+- `VITE_CAPTCHA_BYPASS_TOKEN`: A secret string to bypass captcha in development/tests.
+
+### Bypass for Development
+To avoid captcha checks during local development or automated tests:
+1. Set `VITE_CAPTCHA_BYPASS_TOKEN=my-secret-token` in `.env`.
+2. Ensure the backend accepts this token (server-side validation).
+3. The `CaptchaGate` component will not render the widget and will automatically pass the token.
+
+### Fallback
+If `VITE_CAPTCHA_PROVIDER` is not set or invalid, the component renders a simple "I'm not a robot" checkbox. **This is for UX simulation only and provides NO security.**
+
 ## Future Actions
-- Implement CAPTCHA and visual lockout (FEW-210).
 - Consider alternative storage (httpOnly cookies) if backend opts for changes.
 - Audit dependencies (npm audit) at each release.
 - Document support processes for password reset and account deletion (GDPR).
@@ -34,14 +52,35 @@
 - Erros de autenticação exibem `error_id` para facilitar suporte.
 - Interceptação de 401 força logout e limpeza de storage.
 - Bloqueio manual: usuário pode encerrar sessão via UI (header/mobile).
+- **CaptchaGate**: Proteção em Login, Registro e Reset de Senha.
 
 ### Dependências do Backend
 - Rate limiting, captcha e RBAC serão entregues em **BE-212**.
 - Feature flags de planos (push, relatórios) consumidos via `/api/tenant/meta`.
 - Visibilidade do Feedback é apenas para owner no frontend; o backend pode manter `feedback_enabled` para uso futuro, mas o FE não faz gate por essa flag.
 
+### Configuração de Captcha
+O `CaptchaGate.jsx` suporta múltiplos provedores. Configure via `.env`:
+
+- **Turnstile (Recomendado)**:
+  ```env
+  VITE_CAPTCHA_PROVIDER=turnstile
+  VITE_TURNSTILE_SITEKEY=seu-site-key
+  ```
+
+- **hCaptcha**:
+  ```env
+  VITE_CAPTCHA_PROVIDER=hcaptcha
+  VITE_HCAPTCHA_SITEKEY=seu-site-key
+  ```
+
+- **Bypass (Dev/Testes)**:
+  Defina `VITE_CAPTCHA_BYPASS_TOKEN`. O componente não renderizará o widget e passará o token automaticamente.
+
+- **Modo Fallback**:
+  Se nenhum provider for definido, um checkbox simples será exibido para simular a UX. **Não oferece segurança real.**
+
 ### Ações Futuras
-- Implementar CAPTCHA e lockout visual (FEW-210).
 - Considerar armazenamento alternativo (cookies httpOnly) se o backend optar por mudanças.
 - Auditar dependências (npm audit) a cada release.
 - Documentar processos de suporte para reset de senha e exclusão de conta (GDPR).


### PR DESCRIPTION
- Atualização do .env.example : Adicionadas as variáveis VITE_CAPTCHA_PROVIDER , VITE_TURNSTILE_SITEKEY , e VITE_HCAPTCHA_SITEKEY .
- Atualização do docs/SECURITY_NOTES.md :
- Criada nova seção Captcha Configuration detalhando provedores e bypass.
- Removido item obsoleto "Future Action: Implement CAPTCHA".
- Documentação adicionada em Inglês e Português.
- Referência no README.md : Adicionado link explícito para docs/SECURITY_NOTES.md na seção de desenvolvimento.