### PR TITLE
FIX: Sync tenant_slug from JWT with TenantContext

### DIFF
--- a/salonix-frontend-web/src/contexts/ClientAuthContext.jsx
+++ b/salonix-frontend-web/src/contexts/ClientAuthContext.jsx
@@ -7,8 +7,10 @@ import {
   clearClientTokens,
 } from '../utils/clientAuthStorage';
 import { refreshClientToken } from '../api/clientAccess';
+import { useTenant } from '../hooks/useTenant';
 
 export const ClientAuthProvider = ({ children }) => {
+  const { setTenantSlug: updateGlobalTenantSlug } = useTenant();
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [customerId, setCustomerId] = useState(null);
@@ -41,9 +43,11 @@ export const ClientAuthProvider = ({ children }) => {
         setIsAuthenticated(true);
         setCustomerId(payload.customer_id);
         setTenantSlug(payload.tenant_slug);
+        // Sincronizar tenant_slug do JWT com TenantContext global
+        updateGlobalTenantSlug(payload.tenant_slug);
       }
     },
-    [decodeToken]
+    [decodeToken, updateGlobalTenantSlug]
   );
 
   useEffect(() => {
@@ -63,6 +67,8 @@ export const ClientAuthProvider = ({ children }) => {
           setIsAuthenticated(true);
           setCustomerId(payload.customer_id);
           setTenantSlug(payload.tenant_slug);
+          // Sincronizar tenant_slug do JWT com TenantContext global
+          updateGlobalTenantSlug(payload.tenant_slug);
           setIsLoading(false);
           return;
         }
@@ -78,6 +84,8 @@ export const ClientAuthProvider = ({ children }) => {
             setIsAuthenticated(true);
             setCustomerId(payload.customer_id);
             setTenantSlug(payload.tenant_slug);
+            // Sincronizar tenant_slug do JWT com TenantContext global
+            updateGlobalTenantSlug(payload.tenant_slug);
           }
         }
       } catch (error) {
@@ -102,7 +110,7 @@ export const ClientAuthProvider = ({ children }) => {
     };
 
     bootstrap();
-  }, [decodeToken]);
+  }, [decodeToken, updateGlobalTenantSlug]);
 
   const value = {
     isAuthenticated,

--- a/salonix-frontend-web/src/pages/ClientLogin.jsx
+++ b/salonix-frontend-web/src/pages/ClientLogin.jsx
@@ -5,7 +5,6 @@ import AuthLayout from '../layouts/AuthLayout';
 import FormInput from '../components/ui/FormInput';
 import ErrorPopup from '../components/ui/ErrorPopup';
 import { loginClient } from '../api/clientAccess';
-import { useTenant } from '../hooks/useTenant';
 import { useClientAuth } from '../hooks/useClientAuth';
 import {
   setClientAccessToken,
@@ -15,7 +14,6 @@ import {
 function ClientLogin() {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { setTenantSlug: setContextTenantSlug } = useTenant();
   const { login: clientLogin } = useClientAuth();
 
   const [email, setEmail] = useState('');
@@ -96,9 +94,6 @@ function ClientLogin() {
       if (data.refresh) {
         setClientRefreshToken(data.refresh);
       }
-
-      // Update tenant slug in context (triggers data fetch)
-      setContextTenantSlug(cleanTenantSlug);
 
       // Redirect to client area
       navigate('/client/dashboard');


### PR DESCRIPTION
- ClientAuthContext now syncs tenant_slug from decoded JWT with global TenantContext
- Fixes issue where PWA continued using placeholder tenant (timelyone/timelyone-staging) after login instead of user's actual tenant from JWT token
- Removes manual setTenantSlug call in ClientLogin (now automatic)
- Ensures all API requests use correct tenant after authentication

This fixes the empty services dropdown in PWA after 1-2 hours, which was caused by requests using the wrong tenant slug instead of the authenticated user's tenant.