### PR TITLE
FEW-SEC-02: Validar e restringir redirects externos de checkout/porta…

### DIFF
--- a/salonix-frontend-web/.env.example
+++ b/salonix-frontend-web/.env.example
@@ -18,3 +18,7 @@ VITE_HCAPTCHA_SITEKEY=10000000-ffff-ffff-ffff-000000000001
 # IMPORTANTE: Força novos tenants a passar pelo wizard de seleção de plano após registro
 # Deve ser 'true' em produção para garantir que todos escolham um plano
 VITE_PLAN_WIZARD_AFTER_LOGIN=true
+
+# Hosts permitidos para redirecionamento externo (checkout/portal).
+# Lista separada por vírgula. Se não definido, usa checkout.stripe.com e billing.stripe.com.
+# VITE_ALLOWED_REDIRECT_HOSTS=checkout.stripe.com,billing.stripe.com

--- a/salonix-frontend-web/.env.production
+++ b/salonix-frontend-web/.env.production
@@ -8,3 +8,4 @@ VITE_CAPTCHA_PROVIDER=turnstile
 VITE_TURNSTILE_SITEKEY=your-staging-turnstile-key
 VITE_HCAPTCHA_SITEKEY=your-staging-hcaptcha-key
 VITE_PLAN_WIZARD_AFTER_LOGIN=true
+VITE_ALLOWED_REDIRECT_HOSTS=checkout.stripe.com,billing.stripe.com

--- a/salonix-frontend-web/src/hooks/useCreditPurchase.js
+++ b/salonix-frontend-web/src/hooks/useCreditPurchase.js
@@ -1,6 +1,10 @@
 import { useState, useEffect, useCallback } from 'react';
-import { fetchCreditPackages, createCreditCheckoutSession } from '../api/credits';
+import {
+  fetchCreditPackages,
+  createCreditCheckoutSession,
+} from '../api/credits';
 import { useTenant } from './useTenant';
+import { isRedirectValidationError, safeRedirect } from '../utils/safeRedirect';
 
 /**
  * Hook para gerenciar compra de créditos.
@@ -36,17 +40,26 @@ export default function useCreditPurchase() {
     setPurchaseLoading(true);
     setError(null);
     try {
-      const { checkout_url } = await createCreditCheckoutSession(amountEur, { slug });
+      const { checkout_url } = await createCreditCheckoutSession(amountEur, {
+        slug,
+      });
       if (checkout_url) {
-        console.log('[CreditPurchase] Redirecting to:', checkout_url);
-        window.location.href = checkout_url;
+        safeRedirect(checkout_url);
       } else {
         console.error('[CreditPurchase] No checkout URL returned');
         throw new Error('No checkout URL returned');
       }
     } catch (err) {
       console.error('Failed to start purchase', err);
-      setError(err);
+      if (isRedirectValidationError(err)) {
+        setError({
+          message:
+            'Não foi possível abrir o checkout de créditos com segurança. Tente novamente em instantes.',
+          code: err.code,
+        });
+      } else {
+        setError(err);
+      }
     } finally {
       setPurchaseLoading(false);
     }

--- a/salonix-frontend-web/src/pages/PlanOnboarding.jsx
+++ b/salonix-frontend-web/src/pages/PlanOnboarding.jsx
@@ -6,6 +6,7 @@ import { Lock } from 'lucide-react';
 import { PLAN_OPTIONS, createCheckoutSession } from '../api/billing';
 import { checkFounderAvailability } from '../api/users';
 import { parseApiError } from '../utils/apiError';
+import { isRedirectValidationError, safeRedirect } from '../utils/safeRedirect';
 import { useAuth } from '../hooks/useAuth';
 import { useTenant } from '../hooks/useTenant';
 import useBillingOverview from '../hooks/useBillingOverview';
@@ -108,7 +109,7 @@ export default function PlanOnboarding() {
         interval: billingCycle,
       });
       if (url) {
-        window.location.assign(url);
+        safeRedirect(url);
       } else {
         setError({
           message: t(
@@ -118,12 +119,24 @@ export default function PlanOnboarding() {
         });
       }
     } catch (e) {
-      setError(
-        parseApiError(
-          e,
-          t('plans.checkout_error', 'Falha ao iniciar checkout.')
-        )
-      );
+      if (isRedirectValidationError(e)) {
+        setError({
+          message: t(
+            'plans.checkout_redirect_invalid',
+            'Não foi possível abrir o checkout com segurança. Tente novamente em instantes.'
+          ),
+          code: e.code,
+          details: null,
+          requestId: null,
+        });
+      } else {
+        setError(
+          parseApiError(
+            e,
+            t('plans.checkout_error', 'Falha ao iniciar checkout.')
+          )
+        );
+      }
     } finally {
       setLoading(false);
     }

--- a/salonix-frontend-web/src/pages/Plans.jsx
+++ b/salonix-frontend-web/src/pages/Plans.jsx
@@ -11,6 +11,7 @@ import {
 } from '../api/billing';
 import { checkFounderAvailability } from '../api/users';
 import { parseApiError } from '../utils/apiError';
+import { isRedirectValidationError, safeRedirect } from '../utils/safeRedirect';
 import { useAuth } from '../hooks/useAuth';
 import { useTenant } from '../hooks/useTenant';
 import useBillingOverview from '../hooks/useBillingOverview';
@@ -137,7 +138,7 @@ function Plans() {
         interval: billingCycle,
       });
       if (url) {
-        window.location.assign(url);
+        safeRedirect(url);
       } else {
         setError({
           message: t(
@@ -147,12 +148,24 @@ function Plans() {
         });
       }
     } catch (e) {
-      setError(
-        parseApiError(
-          e,
-          t('plans.checkout_error', 'Falha ao iniciar checkout.')
-        )
-      );
+      if (isRedirectValidationError(e)) {
+        setError({
+          message: t(
+            'plans.checkout_redirect_invalid',
+            'Não foi possível abrir o checkout com segurança. Tente novamente em instantes.'
+          ),
+          code: e.code,
+          details: null,
+          requestId: null,
+        });
+      } else {
+        setError(
+          parseApiError(
+            e,
+            t('plans.checkout_error', 'Falha ao iniciar checkout.')
+          )
+        );
+      }
     } finally {
       setLoading(false);
     }
@@ -168,7 +181,7 @@ function Plans() {
     try {
       const { url } = await createBillingPortalSession({ slug });
       if (url) {
-        window.location.assign(url);
+        safeRedirect(url);
       } else {
         setError({
           message: t(
@@ -178,12 +191,24 @@ function Plans() {
         });
       }
     } catch (e) {
-      setError(
-        parseApiError(
-          e,
-          t('plans.portal_error', 'Falha ao abrir o portal de faturação.')
-        )
-      );
+      if (isRedirectValidationError(e)) {
+        setError({
+          message: t(
+            'plans.portal_redirect_invalid',
+            'Não foi possível abrir o portal de faturação com segurança. Tente novamente em instantes.'
+          ),
+          code: e.code,
+          details: null,
+          requestId: null,
+        });
+      } else {
+        setError(
+          parseApiError(
+            e,
+            t('plans.portal_error', 'Falha ao abrir o portal de faturação.')
+          )
+        );
+      }
     } finally {
       setManaging(false);
     }

--- a/salonix-frontend-web/src/pages/RegisterCheckout.jsx
+++ b/salonix-frontend-web/src/pages/RegisterCheckout.jsx
@@ -6,6 +6,7 @@ import { Lock } from 'lucide-react';
 import { PLAN_OPTIONS, createCheckoutSession } from '../api/billing';
 import { checkFounderAvailability } from '../api/users';
 import { parseApiError } from '../utils/apiError';
+import { isRedirectValidationError, safeRedirect } from '../utils/safeRedirect';
 import { useAuth } from '../hooks/useAuth';
 import { useTenant } from '../hooks/useTenant';
 
@@ -48,7 +49,7 @@ function RegisterCheckout() {
         interval: billingCycle,
       });
       if (url) {
-        window.location.assign(url);
+        safeRedirect(url);
       } else {
         setError({
           message: t(
@@ -58,12 +59,24 @@ function RegisterCheckout() {
         });
       }
     } catch (e) {
-      setError(
-        parseApiError(
-          e,
-          t('plans.checkout_error', 'Falha ao iniciar checkout.')
-        )
-      );
+      if (isRedirectValidationError(e)) {
+        setError({
+          message: t(
+            'plans.checkout_redirect_invalid',
+            'Não foi possível abrir o checkout com segurança. Tente novamente em instantes.'
+          ),
+          code: e.code,
+          details: null,
+          requestId: null,
+        });
+      } else {
+        setError(
+          parseApiError(
+            e,
+            t('plans.checkout_error', 'Falha ao iniciar checkout.')
+          )
+        );
+      }
     } finally {
       setLoading(false);
     }

--- a/salonix-frontend-web/src/pages/__tests__/PlanOnboarding.test.jsx
+++ b/salonix-frontend-web/src/pages/__tests__/PlanOnboarding.test.jsx
@@ -4,6 +4,8 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import PlanOnboarding from '../PlanOnboarding';
 import * as billingApi from '../../api/billing';
+import * as safeRedirectUtils from '../../utils/safeRedirect';
+import * as usersApi from '../../api/users';
 
 jest.mock('../../hooks/useAuth', () => ({
   useAuth: () => ({ isAuthenticated: true }),
@@ -33,6 +35,18 @@ jest.mock('../../api/billing', () => ({
   })),
 }));
 
+jest.mock('../../api/users', () => ({
+  checkFounderAvailability: jest.fn(async () => ({
+    available: false,
+  })),
+}));
+
+jest.mock('../../utils/safeRedirect', () => ({
+  safeRedirect: jest.fn(),
+  isRedirectValidationError: jest.fn(),
+  REDIRECT_VALIDATION_ERROR_CODE: 'REDIRECT_URL_BLOCKED',
+}));
+
 describe('PlanOnboarding', () => {
   const originalError = console.error;
 
@@ -47,6 +61,16 @@ describe('PlanOnboarding', () => {
 
   afterAll(() => {
     console.error = originalError;
+  });
+
+  beforeEach(() => {
+    safeRedirectUtils.safeRedirect.mockReset();
+    safeRedirectUtils.isRedirectValidationError.mockReset();
+    safeRedirectUtils.isRedirectValidationError.mockReturnValue(false);
+    usersApi.checkFounderAvailability.mockResolvedValue({ available: false });
+    billingApi.createCheckoutSession.mockResolvedValue({
+      url: 'https://checkout.stripe.com/pay/cs_test_123',
+    });
   });
 
   it('abre modal de confirmação e inicia checkout ao confirmar', async () => {
@@ -66,6 +90,9 @@ describe('PlanOnboarding', () => {
 
     await waitFor(() => {
       expect(billingApi.createCheckoutSession).toHaveBeenCalled();
+      expect(safeRedirectUtils.safeRedirect).toHaveBeenCalledWith(
+        'https://checkout.stripe.com/pay/cs_test_123'
+      );
     });
   });
 
@@ -87,5 +114,37 @@ describe('PlanOnboarding', () => {
       const stored = window.localStorage.getItem('onboarding.plan.selection');
       expect(stored).toBeTruthy();
     });
+  });
+
+  it('mostra erro amigável quando o redirect é bloqueado', async () => {
+    const redirectError = new TypeError('Redirect URL failed validation.');
+    redirectError.code = 'REDIRECT_URL_BLOCKED';
+
+    safeRedirectUtils.safeRedirect.mockImplementation(() => {
+      throw redirectError;
+    });
+    safeRedirectUtils.isRedirectValidationError.mockImplementation(
+      (error) => error?.code === 'REDIRECT_URL_BLOCKED'
+    );
+
+    render(
+      <MemoryRouter>
+        <PlanOnboarding />
+      </MemoryRouter>
+    );
+
+    const continueBtn = await screen.findByText(/Continuar para checkout/i);
+    fireEvent.click(continueBtn);
+
+    const confirmInModal = await screen.findAllByText(
+      /Continuar para checkout/i
+    );
+    fireEvent.click(confirmInModal[confirmInModal.length - 1]);
+
+    expect(
+      await screen.findByText(
+        /Não foi possível abrir o checkout com segurança/i
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/salonix-frontend-web/src/utils/__tests__/safeRedirect.test.js
+++ b/salonix-frontend-web/src/utils/__tests__/safeRedirect.test.js
@@ -1,0 +1,58 @@
+/* eslint-env jest */
+import {
+  isAllowedRedirectUrl,
+  isRedirectValidationError,
+  REDIRECT_VALIDATION_ERROR_CODE,
+  safeRedirect,
+} from '../safeRedirect';
+import { resetEnvCache } from '../env';
+
+describe('safeRedirect', () => {
+  const originalEnv = process.env.VITE_ALLOWED_REDIRECT_HOSTS;
+
+  beforeEach(() => {
+    process.env.VITE_ALLOWED_REDIRECT_HOSTS =
+      'checkout.stripe.com,billing.stripe.com';
+    resetEnvCache();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.VITE_ALLOWED_REDIRECT_HOSTS;
+    } else {
+      process.env.VITE_ALLOWED_REDIRECT_HOSTS = originalEnv;
+    }
+    resetEnvCache();
+    jest.restoreAllMocks();
+  });
+
+  it('permite URL https para host configurado', () => {
+    expect(
+      isAllowedRedirectUrl('https://checkout.stripe.com/pay/cs_test_123')
+    ).toBe(true);
+  });
+
+  it('bloqueia URL com protocolo inseguro', () => {
+    expect(
+      isAllowedRedirectUrl('http://checkout.stripe.com/pay/cs_test_123')
+    ).toBe(false);
+  });
+
+  it('bloqueia URL com host não permitido', () => {
+    expect(
+      isAllowedRedirectUrl('https://evil.example.com/pay/cs_test_123')
+    ).toBe(false);
+  });
+
+  it('lança erro tipado quando tenta redirecionar para URL inválida', () => {
+    expect.assertions(3);
+
+    try {
+      safeRedirect('https://evil.example.com/pay/cs_test_123');
+    } catch (error) {
+      expect(isRedirectValidationError(error)).toBe(true);
+      expect(error.code).toBe(REDIRECT_VALIDATION_ERROR_CODE);
+      expect(error.blockedUrl).toBe('https://evil.example.com/pay/cs_test_123');
+    }
+  });
+});

--- a/salonix-frontend-web/src/utils/safeRedirect.js
+++ b/salonix-frontend-web/src/utils/safeRedirect.js
@@ -1,0 +1,79 @@
+/**
+ * safeRedirect.js
+ *
+ * Validates URLs returned by the API before redirecting the user.
+ * Prevents open-redirect vulnerabilities by allowing only trusted hosts
+ * and HTTPS protocol.
+ *
+ * Allowed hosts are configured via the VITE_ALLOWED_REDIRECT_HOSTS env var
+ * (comma-separated list). Falls back to the built-in Stripe hosts when the
+ * variable is not set.
+ */
+
+import { getEnvVar } from './env';
+
+const BUILTIN_ALLOWED_HOSTS = ['checkout.stripe.com', 'billing.stripe.com'];
+export const REDIRECT_VALIDATION_ERROR_CODE = 'REDIRECT_URL_BLOCKED';
+
+/**
+ * Returns the set of allowed redirect hosts for the current environment.
+ * @returns {string[]}
+ */
+function getAllowedHosts() {
+  const envHosts = getEnvVar('VITE_ALLOWED_REDIRECT_HOSTS');
+  if (envHosts && envHosts.trim()) {
+    return envHosts
+      .split(',')
+      .map((h) => h.trim().toLowerCase())
+      .filter(Boolean);
+  }
+  return BUILTIN_ALLOWED_HOSTS;
+}
+
+/**
+ * Returns true if the URL is safe to redirect to:
+ * - Protocol must be https:
+ * - Hostname must be in the allowed hosts list
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+export function isAllowedRedirectUrl(url) {
+  if (!url || typeof url !== 'string') return false;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'https:') return false;
+    const host = parsed.hostname.toLowerCase();
+    return getAllowedHosts().some(
+      (allowed) => host === allowed || host.endsWith(`.${allowed}`)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function isRedirectValidationError(error) {
+  return error?.code === REDIRECT_VALIDATION_ERROR_CODE;
+}
+
+export function toRedirectValidationError(url) {
+  const error = new TypeError('Redirect URL failed validation.');
+  error.code = REDIRECT_VALIDATION_ERROR_CODE;
+  error.blockedUrl = url;
+  return error;
+}
+
+/**
+ * Validates the URL and redirects via window.location.assign.
+ * Throws a TypeError if the URL is not allowed — callers must handle this
+ * and show an appropriate error to the user instead of redirecting.
+ *
+ * @param {string} url
+ * @throws {TypeError} when the URL is invalid or not allowed
+ */
+export function safeRedirect(url) {
+  if (!isAllowedRedirectUrl(url)) {
+    throw toRedirectValidationError(url);
+  }
+  window.location.assign(url);
+}


### PR DESCRIPTION
validação de protocolo e host em salonix-frontend-web/salonix-frontend-web/src/utils/safeRedirect.js
allowlist por ambiente em salonix-frontend-web/salonix-frontend-web/.env.production e referência em salonix-frontend-web/salonix-frontend-web/.env.example
fallback amigável nos fluxos de checkout, portal e créditos
cobertura de testes em salonix-frontend-web/salonix-frontend-web/src/utils/tests/safeRedirect.test.js e salonix-frontend-web/salonix-frontend-web/src/pages/tests/PlanOnboarding.test.jsx
Validação final já executada:

npx jest src/utils/__tests__/safeRedirect.test.js src/pages/__tests__/PlanOnboarding.test.jsx --no-coverage
resultado: 7 testes passando