### PR TITLE
FEW-PLANS-04: Card único de plano em RegisterCheckout e PlanOnboarding

### DIFF
--- a/salonix-frontend-web/src/pages/PlanOnboarding.jsx
+++ b/salonix-frontend-web/src/pages/PlanOnboarding.jsx
@@ -13,23 +13,23 @@ import { mergePlanAvailability } from '../utils/planAvailability';
 export default function PlanOnboarding() {
   const { t } = useTranslation();
   const { isAuthenticated } = useAuth();
-  const { plan, slug, refetch } = useTenant();
+  const { slug, refetch } = useTenant();
   const {
     overview,
     loading: overviewLoading,
     refresh: refreshOverview,
   } = useBillingOverview({ pollIntervalMs: 3000 });
-  const [selected, setSelected] = useState('basic');
   const [billingCycle, setBillingCycle] = useState('monthly');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
-  const [showFounderWarning, setShowFounderWarning] = useState(false);
 
   const plans = useMemo(
     () => mergePlanAvailability(PLAN_OPTIONS, overview?.available_plans),
     [overview?.available_plans]
   );
+
+  const plan = plans[0];
 
   useEffect(() => {
     if (overview) {
@@ -41,17 +41,6 @@ export default function PlanOnboarding() {
       });
     }
   }, [overview]);
-
-  useEffect(() => {
-    const fromOverview = (
-      overview?.current_subscription?.plan_code || ''
-    ).toLowerCase();
-    const tier = (plan?.tier || plan?.code || '').toLowerCase();
-    const candidate = fromOverview || tier;
-    if (candidate && ['basic', 'pro'].includes(candidate)) {
-      setSelected(candidate);
-    }
-  }, [overview?.current_subscription?.plan_code, plan?.tier, plan?.code]);
 
   useEffect(() => {
     const handleFocus = () => {
@@ -84,12 +73,12 @@ export default function PlanOnboarding() {
       try {
         localStorage.setItem(
           'onboarding.plan.selection',
-          JSON.stringify({ plan: selected, startedAt: Date.now() })
+          JSON.stringify({ plan: plan?.code, startedAt: Date.now() })
         );
       } catch {
         /* noop */
       }
-      const { url } = await createCheckoutSession(selected, {
+      const { url } = await createCheckoutSession(plan?.code, {
         slug,
         interval: billingCycle,
       });
@@ -125,13 +114,11 @@ export default function PlanOnboarding() {
     } finally {
       setLoading(false);
     }
-  }, [selected, slug, t, billingCycle]);
+  }, [plan?.code, slug, t, billingCycle]);
 
   const onContinue = useCallback(() => {
     setConfirmOpen(true);
   }, []);
-
-  const selectedPlan = plans.find((p) => p.code === selected);
 
   return (
     <AuthLayout>
@@ -189,85 +176,52 @@ export default function PlanOnboarding() {
           </div>
         </div>
 
-        <div className="grid gap-3 sm:grid-cols-2">
-          {plans.map((p) => {
-            const isAnnual = billingCycle === 'annual';
-            const showPrice =
-              isAnnual && p.price_annual ? p.price_annual : p.price;
-            return (
-              <button
-                key={p.code}
-                type="button"
-                className={`relative rounded border p-4 text-left transition hover:shadow ${
-                  selected === p.code
-                    ? 'border-brand-primary ring-2 ring-brand-primary/40'
-                    : p.code === 'founder'
-                      ? 'border-yellow-500/50 bg-yellow-50/50 dark:bg-yellow-900/10'
-                      : 'border-gray-200 dark:border-gray-700'
-                }`}
-                onClick={() => {
-                  if (p.code === 'founder') {
-                    setShowFounderWarning(true);
-                  } else {
-                    setSelected(p.code);
-                  }
-                }}
-              >
-                {p.code === 'founder' && (
-                  <div className="mb-2 inline-block rounded-full bg-amber-500 px-2 py-1 text-xs font-bold text-white">
-                    {t(
-                      'plans.founder.limited_badge',
-                      'Oferta de lançamento — limitada a 500 contas'
-                    )}
+        {plan && (
+          <div className="grid gap-3">
+            {(() => {
+              const isAnnual = billingCycle === 'annual';
+              const showPrice =
+                isAnnual && plan.price_annual ? plan.price_annual : plan.price;
+              return (
+                <div className="relative rounded border border-brand-primary p-4 text-left ring-2 ring-brand-primary/40">
+                  <div className="text-base font-semibold flex items-center gap-2">
+                    {t(`plans.options.${plan.code}.name`, plan.name)}
                   </div>
-                )}
-                <div className="text-base font-semibold flex items-center gap-2">
-                  {t(`plans.options.${p.code}.name`, p.name)}
-                  {p.code === 'founder' && (
-                    <span className="rounded-full bg-yellow-100 px-2 py-0.5 text-[10px] font-bold text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200">
-                      {t(`plans.options.${p.code}.badge`, 'Oferta Limitada')}
+                  <div className="mt-1 text-sm text-gray-600 flex items-baseline gap-1">
+                    <span>
+                      {t(
+                        `plans.options.${plan.code}.price_${isAnnual ? 'annual' : 'monthly'}`,
+                        showPrice
+                      )}
                     </span>
+                    <span className="text-xs text-gray-400">
+                      {isAnnual ? t('plans.per_year') : t('plans.per_month')}
+                    </span>
+                  </div>
+                  {isAnnual && plan.price_annual && (
+                    <p className="mt-1 text-[10px] font-bold text-emerald-600">
+                      {t('plans.savings', 'Poupe 2 meses')}
+                    </p>
                   )}
+                  {Array.isArray(plan.highlights) && plan.highlights.length ? (
+                    <ul className="mt-2 list-disc pl-4 text-xs text-gray-500">
+                      {plan.highlights.slice(0, 3).map((h, idx) => (
+                        <li key={idx}>
+                          {t(`plans.options.${plan.code}.highlights.${idx}`, h)}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
                 </div>
-                <div className="mt-1 text-sm text-gray-600 flex items-baseline gap-1">
-                  <span>
-                    {t(
-                      `plans.options.${p.code}.price_${isAnnual ? 'annual' : 'monthly'}`,
-                      showPrice
-                    )}
-                  </span>
-                  <span className="text-xs text-gray-400">
-                    {isAnnual ? t('plans.per_year') : t('plans.per_month')}
-                  </span>
-                </div>
-                {isAnnual && p.price_annual && (
-                  <p className="mt-1 text-[10px] font-bold text-emerald-600">
-                    {p.code === 'founder'
-                      ? t(
-                          'plans.founder.annual_savings',
-                          '(10 meses pagos, 2 grátis) - Vitalício'
-                        )
-                      : t('plans.savings', 'Poupe 2 meses')}
-                  </p>
-                )}
-                {Array.isArray(p.highlights) && p.highlights.length ? (
-                  <ul className="mt-2 list-disc pl-4 text-xs text-gray-500">
-                    {p.highlights.slice(0, 3).map((h, idx) => (
-                      <li key={idx}>
-                        {t(`plans.options.${p.code}.highlights.${idx}`, h)}
-                      </li>
-                    ))}
-                  </ul>
-                ) : null}
-              </button>
-            );
-          })}
-        </div>
+              );
+            })()}
+          </div>
+        )}
 
         <div className="pt-2">
           <button
             type="button"
-            disabled={loading || !isAuthenticated || !selectedPlan?.is_available}
+            disabled={loading || !isAuthenticated || !plan?.is_available}
             onClick={onContinue}
             className="text-brand-primary underline hover:text-brand-primary/80 disabled:cursor-not-allowed disabled:opacity-50"
           >
@@ -298,7 +252,7 @@ export default function PlanOnboarding() {
             </button>
             <button
               type="button"
-              disabled={loading || !isAuthenticated || !selectedPlan?.is_available}
+              disabled={loading || !isAuthenticated || !plan?.is_available}
               onClick={confirmCheckout}
               className="text-brand-primary underline underline-offset-4 hover:text-brand-primary/80 disabled:opacity-50 disabled:cursor-not-allowed"
             >
@@ -315,7 +269,7 @@ export default function PlanOnboarding() {
               {t('plans.summary.plan', 'Plano selecionado')}
             </p>
             <p className="text-sm text-brand-surfaceForeground/70">
-              {t(`plans.options.${selected}.name`, selected)}
+              {t(`plans.options.${plan?.code}.name`, plan?.name)}
             </p>
           </div>
           <div className="rounded border border-brand-border bg-brand-light p-4">
@@ -324,12 +278,13 @@ export default function PlanOnboarding() {
             </p>
             <p className="text-sm text-brand-surfaceForeground/70">
               {(() => {
-                const p = plans.find((pl) => pl.code === selected) || {};
                 const isAnnual = billingCycle === 'annual';
                 const showPrice =
-                  isAnnual && p.price_annual ? p.price_annual : p.price;
+                  isAnnual && plan?.price_annual
+                    ? plan.price_annual
+                    : plan?.price;
                 return t(
-                  `plans.options.${selected}.price_${isAnnual ? 'annual' : 'monthly'}`,
+                  `plans.options.${plan?.code}.price_${isAnnual ? 'annual' : 'monthly'}`,
                   showPrice
                 );
               })()}
@@ -337,72 +292,6 @@ export default function PlanOnboarding() {
           </div>
         </div>
       </Modal>
-
-      {/* Modal de Warning do Plano Founder */}
-      {showFounderWarning && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="mx-4 max-w-md rounded-lg bg-white p-6 shadow-xl dark:bg-gray-800">
-            <div className="mb-4 flex items-start gap-3">
-              <div className="flex-shrink-0 rounded-full bg-amber-100 p-2 dark:bg-amber-900/30">
-                <svg
-                  className="h-6 w-6 text-amber-600 dark:text-amber-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-                  />
-                </svg>
-              </div>
-              <div className="flex-1">
-                <h3 className="mb-2 text-lg font-bold text-gray-900 dark:text-white">
-                  {t(
-                    'plans.founder.warning_title',
-                    'Plano Founder: Oferta de Lançamento'
-                  )}
-                </h3>
-                <p className="mb-4 text-sm text-gray-700 dark:text-gray-300">
-                  {t(
-                    'plans.founder.warning_message',
-                    'O plano Founder é uma oferta de lançamento limitada às primeiras 500 contas. O preço de €15/mês fica garantido para sempre.'
-                  )}
-                </p>
-                <div className="rounded-lg bg-amber-50 p-3 dark:bg-amber-900/20">
-                  <p className="text-xs font-medium text-amber-800 dark:text-amber-300">
-                    {t(
-                      'plans.founder.warning_note',
-                      '💡 Este plano foi criado para apoiar os primeiros 500 clientes da TimelyOne.'
-                    )}
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div className="flex gap-3">
-              <button
-                type="button"
-                className="flex-1 text-center text-sm font-medium text-gray-600 hover:text-gray-900 hover:underline dark:text-gray-400 dark:hover:text-gray-200"
-                onClick={() => setShowFounderWarning(false)}
-              >
-                {t('plans.founder.warning_cancel', 'Cancelar')}
-              </button>
-              <button
-                type="button"
-                className="flex-1 text-center text-sm font-medium text-brand-primary hover:text-brand-primary/80 hover:underline dark:text-brand-primary-light"
-                onClick={() => {
-                  setSelected('founder');
-                  setShowFounderWarning(false);
-                }}
-              >
-                {t('plans.founder.warning_confirm', 'Entendi, Continuar')}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </AuthLayout>
   );
 }

--- a/salonix-frontend-web/src/pages/RegisterCheckout.jsx
+++ b/salonix-frontend-web/src/pages/RegisterCheckout.jsx
@@ -20,7 +20,7 @@ function RegisterCheckout() {
     [overview?.available_plans]
   );
 
-  const [selected, setSelected] = useState('basic');
+  const plan = plans[0];
   const [billingCycle, setBillingCycle] = useState(
     searchParams.get('interval') === 'annual' ? 'annual' : 'monthly'
   );
@@ -31,7 +31,7 @@ function RegisterCheckout() {
     setLoading(true);
     setError(null);
     try {
-      const { url } = await createCheckoutSession(selected, {
+      const { url } = await createCheckoutSession(plan?.code, {
         slug,
         interval: billingCycle,
       });
@@ -67,9 +67,7 @@ function RegisterCheckout() {
     } finally {
       setLoading(false);
     }
-  }, [selected, slug, billingCycle, t]);
-
-  const selectedPlan = plans.find((p) => p.code === selected);
+  }, [plan?.code, slug, billingCycle, t]);
 
   return (
     <div className="min-h-screen theme-bg-primary theme-text-primary flex items-center justify-center px-4">
@@ -119,62 +117,55 @@ function RegisterCheckout() {
           </div>
         )}
 
-        <div className="mt-6 grid gap-4 sm:grid-cols-2">
-          {plans.map((p) => {
-            const isAnnual = billingCycle === 'annual';
-            const showPrice =
-              isAnnual && p.price_annual ? p.price_annual : p.price;
+        {plan && (
+          <div className="mt-6">
+            {(() => {
+              const isAnnual = billingCycle === 'annual';
+              const showPrice =
+                isAnnual && plan.price_annual ? plan.price_annual : plan.price;
 
-            return (
-              <button
-                key={p.code}
-                type="button"
-                className={`relative rounded border p-4 text-left transition hover:shadow ${
-                  selected === p.code
-                    ? 'border-brand-primary ring-2 ring-brand-primary/40'
-                    : 'border-brand-border'
-                }`}
-                onClick={() => setSelected(p.code)}
-              >
-                <div className="text-lg font-semibold text-brand-surfaceForeground">
-                  {t(`plans.options.${p.code}.name`, p.name)}
+              return (
+                <div className="relative rounded border border-brand-primary p-4 text-left ring-2 ring-brand-primary/40">
+                  <div className="text-lg font-semibold text-brand-surfaceForeground">
+                    {t(`plans.options.${plan.code}.name`, plan.name)}
+                  </div>
+                  <div className="mt-1 flex items-baseline gap-1">
+                    <span className="text-xl font-bold text-brand-surfaceForeground">
+                      {t(
+                        `plans.options.${plan.code}.price_${isAnnual ? 'annual' : 'monthly'}`,
+                        showPrice
+                      )}
+                    </span>
+                    <span className="text-xs text-brand-surfaceForeground/60">
+                      {isAnnual ? t('plans.per_year') : t('plans.per_month')}
+                    </span>
+                  </div>
+
+                  {isAnnual && plan.price_annual && (
+                    <p className="mt-1 text-[10px] font-bold text-emerald-600">
+                      Poupe 2 meses
+                    </p>
+                  )}
+
+                  {Array.isArray(plan.highlights) && plan.highlights.length ? (
+                    <ul className="mt-3 list-disc pl-4 text-xs text-brand-surfaceForeground/60">
+                      {plan.highlights.slice(0, 4).map((h, idx) => (
+                        <li key={idx}>
+                          {t(`plans.options.${plan.code}.highlights.${idx}`, h)}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
                 </div>
-                <div className="mt-1 flex items-baseline gap-1">
-                  <span className="text-xl font-bold text-brand-surfaceForeground">
-                    {t(
-                      `plans.options.${p.code}.price_${isAnnual ? 'annual' : 'monthly'}`,
-                      showPrice
-                    )}
-                  </span>
-                  <span className="text-xs text-brand-surfaceForeground/60">
-                    {isAnnual ? t('plans.per_year') : t('plans.per_month')}
-                  </span>
-                </div>
-
-                {isAnnual && p.price_annual && (
-                  <p className="mt-1 text-[10px] font-bold text-emerald-600">
-                    Poupe 2 meses
-                  </p>
-                )}
-
-                {Array.isArray(p.highlights) && p.highlights.length ? (
-                  <ul className="mt-3 list-disc pl-4 text-xs text-brand-surfaceForeground/60">
-                    {p.highlights.slice(0, 4).map((h, idx) => (
-                      <li key={idx}>
-                        {t(`plans.options.${p.code}.highlights.${idx}`, h)}
-                      </li>
-                    ))}
-                  </ul>
-                ) : null}
-              </button>
-            );
-          })}
-        </div>
+              );
+            })()}
+          </div>
+        )}
 
         <div className="mt-6 text-center">
           <button
             type="button"
-            disabled={loading || !isAuthenticated || !selectedPlan?.is_available}
+            disabled={loading || !isAuthenticated || !plan?.is_available}
             onClick={onContinue}
             className="text-brand-primary underline hover:text-brand-primary/80 disabled:cursor-not-allowed disabled:opacity-50"
           >

--- a/salonix-frontend-web/src/pages/__tests__/PlanOnboarding.test.jsx
+++ b/salonix-frontend-web/src/pages/__tests__/PlanOnboarding.test.jsx
@@ -149,4 +149,23 @@ describe('PlanOnboarding', () => {
       )
     ).toBeInTheDocument();
   });
+
+  it('renders the plan area as a static, non-interactive card with no founder-warning trigger left', async () => {
+    render(
+      <MemoryRouter>
+        <PlanOnboarding />
+      </MemoryRouter>
+    );
+
+    const planName = await screen.findByText('TimelyOne');
+    // The plan card must not be a clickable element anymore.
+    expect(planName.closest('button')).toBeNull();
+
+    // The Founder warning modal (and its trigger) must be entirely gone —
+    // clicking the plan area used to open it, but there is nothing left to click.
+    expect(
+      screen.queryByText(/Plano Founder: Oferta de Lançamento/i)
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Entendi, Continuar/i)).not.toBeInTheDocument();
+  });
 });

--- a/salonix-frontend-web/src/pages/__tests__/RegisterCheckout.test.jsx
+++ b/salonix-frontend-web/src/pages/__tests__/RegisterCheckout.test.jsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import RegisterCheckout from '../RegisterCheckout';
+import { createCheckoutSession } from '../../api/billing';
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key, fallback) => fallback || key }),
@@ -62,5 +63,58 @@ describe('RegisterCheckout', () => {
 
     const continueBtn = await screen.findByText(/Continuar para checkout/i);
     expect(continueBtn.closest('button')).not.toBeDisabled();
+  });
+
+  it('renders the single plan returned by the backend as a static, non-clickable card', async () => {
+    mockOverview = {
+      available_plans: [
+        { plan_code: 'founder', is_available: true, is_current: false, can_upgrade: true },
+      ],
+    };
+
+    render(
+      <MemoryRouter>
+        <RegisterCheckout />
+      </MemoryRouter>
+    );
+
+    const planName = await screen.findByText('Founder');
+    // The plan card must not be a clickable element anymore.
+    expect(planName.closest('button')).toBeNull();
+
+    // Only the plan the backend returned is shown — the other PLAN_OPTIONS entry
+    // (basic) that mergePlanAvailability filtered out must not be rendered.
+    expect(screen.queryByText('TimelyOne')).not.toBeInTheDocument();
+  });
+
+  it('keeps checking out the only available plan even if the plan card area is clicked', async () => {
+    createCheckoutSession.mockClear();
+    createCheckoutSession.mockResolvedValue({ url: 'https://checkout.example/session' });
+
+    mockOverview = {
+      available_plans: [
+        { plan_code: 'founder', is_available: true, is_current: false, can_upgrade: true },
+      ],
+    };
+
+    render(
+      <MemoryRouter>
+        <RegisterCheckout />
+      </MemoryRouter>
+    );
+
+    const planName = await screen.findByText('Founder');
+    // Clicking the plan card must not throw/change anything since there is no
+    // plan-switching UI left; the checkout call still targets 'founder'.
+    planName.click();
+
+    const continueBtn = await screen.findByText(/Continuar para checkout/i);
+    await act(async () => {
+      continueBtn.click();
+    });
+    expect(createCheckoutSession).toHaveBeenCalledWith(
+      'founder',
+      expect.objectContaining({ slug: 'aurora' })
+    );
   });
 });


### PR DESCRIPTION
O backend agora devolve sempre um único plano atribuído ao tenant, por isso RegisterCheckout.jsx e PlanOnboarding.jsx deixam de mostrar uma grelha de cards clicáveis e passam a mostrar o plano diretamente como card estático, mantendo o toggle mensal/anual. Remove o modal de aviso Founder em PlanOnboarding, que ficou inatingível.

## Descrição

<!-- Descreva o que esta PR faz e por quê -->

Closes #

---

## Tipo de mudança

- [ ] Bug fix
- [ ] Nova feature
- [ ] Refactor
- [ ] Segurança
- [ ] Docs / config

---

## Checklist de Segurança FEW

Marque os itens relevantes para esta PR. Se o item não se aplica, marque N/A.

### Execução de Código
- [ ] Não há uso de `eval()`, `new Function()`, ou `setTimeout(string)`
- [ ] Não há uso de `dangerouslySetInnerHTML` sem sanitização (ex: DOMPurify)
- [ ] Não há construção de HTML por concatenação de strings

### Tokens e Dados Sensíveis
- [ ] Tokens não são expostos em query strings de URLs
- [ ] Tokens não aparecem em logs (`console.log`, telemetry events)
- [ ] Links com tokens usam header ou rid em vez de `?token=`
- [ ] Emails/SMS não contêm tokens diretos (usar rid com TTL)

### Redirecionamentos
- [ ] Redirecionamentos externos passam por `safeRedirect()` de `src/utils/safeRedirect`
- [ ] Links externos usam `rel="noreferrer"` ou `referrerPolicy: 'no-referrer'`
- [ ] Não há `window.location = userInput` sem validação

### Formulários e Inputs
- [ ] Inputs de usuário não são usados como seletores CSS ou caminhos de URL diretos
- [ ] Upload de arquivos valida tipo e tamanho antes de enviar
- [ ] Dados de formulário são enviados via HTTPS (fetch com URL relativa ou VITE_API_URL)

### Dependências Externas
- [ ] Scripts externos (captcha, analytics) não foram adicionados sem aprovação
- [ ] Não há chamadas para CDNs externos não aprovados
- [ ] N/A — nenhuma dependência externa nova

### Testes
- [ ] Testes existentes continuam passando (`npm test -- --no-coverage`)
- [ ] Cenários de segurança afetados têm cobertura de testes
- [ ] N/A — mudança não afeta fluxos de segurança

---

## Notas

<!-- Observações, decisões técnicas, ou pontos de atenção para o reviewer -->
