### PR TITLE
fix: captcha de registo público nunca carregava (404 sempre)

### DIFF
--- a/salonix-frontend-web/src/api/__tests__/captcha.test.js
+++ b/salonix-frontend-web/src/api/__tests__/captcha.test.js
@@ -13,7 +13,12 @@ describe('fetchCaptchaChallenge', () => {
 
     const result = await fetchCaptchaChallenge();
 
-    expect(client.get).toHaveBeenCalledWith('captcha/refresh/');
+    // django-simple-captcha's 'captcha/refresh/' rejects any request without
+    // the X-Requested-With: XMLHttpRequest header (which axios never sends),
+    // always 404ing in real usage. Use our own endpoint instead, which
+    // returns the same {key, image_url} shape and validates against the
+    // same CaptchaStore.
+    expect(client.get).toHaveBeenCalledWith('captcha/new/');
     expect(result).toEqual({
       key: 'abc123',
       image_url: '/api/captcha/image/abc123/',

--- a/salonix-frontend-web/src/api/captcha.js
+++ b/salonix-frontend-web/src/api/captcha.js
@@ -2,9 +2,15 @@ import client from './client';
 
 /**
  * Busca um novo desafio de captcha (key + URL da imagem) do backend.
- * Usado no registo público de clientes (django-simple-captcha).
+ * Usado no registo público de clientes.
+ *
+ * Usa o endpoint próprio ('captcha/new/'), não o 'captcha/refresh/' do
+ * django-simple-captcha — esse exige o header X-Requested-With:
+ * XMLHttpRequest, que o axios não envia, o que faz o endpoint devolver
+ * sempre 404. O endpoint próprio devolve a mesma forma de resposta
+ * ({key, image_url}) e valida contra o mesmo CaptchaStore.
  */
 export async function fetchCaptchaChallenge() {
-  const { data } = await client.get('captcha/refresh/');
+  const { data } = await client.get('captcha/new/');
   return data;
 }


### PR DESCRIPTION
O captcha de /join/:tenantSlug chamava 'captcha/refresh/', endpoint do django-simple-captcha que exige o header X-Requested-With: XMLHttpRequest — o axios nunca envia esse header, então a chamada dava sempre 404 em qualquer browser/ambiente. Troca para 'captcha/new/' (endpoint próprio já existente, mesma resposta {key, image_url}, mesma validação via CaptchaStore), que não tem essa restrição.

## Descrição

<!-- Descreva o que esta PR faz e por quê -->

Closes #

---

## Tipo de mudança

- [x] Bug fix
- [ ] Nova feature
- [ ] Refactor
- [ ] Segurança
- [ ] Docs / config

---

## Checklist de Segurança FEW

Marque os itens relevantes para esta PR. Se o item não se aplica, marque N/A.

### Execução de Código
- [x] Não há uso de `eval()`, `new Function()`, ou `setTimeout(string)`
- [ ] Não há uso de `dangerouslySetInnerHTML` sem sanitização (ex: DOMPurify)
- [ ] Não há construção de HTML por concatenação de strings

### Tokens e Dados Sensíveis
- [x] Tokens não são expostos em query strings de URLs
- [ ] Tokens não aparecem em logs (`console.log`, telemetry events)
- [ ] Links com tokens usam header ou rid em vez de `?token=`
- [ ] Emails/SMS não contêm tokens diretos (usar rid com TTL)

### Redirecionamentos
- [x] Redirecionamentos externos passam por `safeRedirect()` de `src/utils/safeRedirect`
- [ ] Links externos usam `rel="noreferrer"` ou `referrerPolicy: 'no-referrer'`
- [ ] Não há `window.location = userInput` sem validação

### Formulários e Inputs
- [ ] Inputs de usuário não são usados como seletores CSS ou caminhos de URL diretos
- [ ] Upload de arquivos valida tipo e tamanho antes de enviar
- [ ] Dados de formulário são enviados via HTTPS (fetch com URL relativa ou VITE_API_URL)

### Dependências Externas
- [ ] Scripts externos (captcha, analytics) não foram adicionados sem aprovação
- [ ] Não há chamadas para CDNs externos não aprovados
- [ ] N/A — nenhuma dependência externa nova

### Testes
- [ ] Testes existentes continuam passando (`npm test -- --no-coverage`)
- [ ] Cenários de segurança afetados têm cobertura de testes
- [ ] N/A — mudança não afeta fluxos de segurança

---

## Notas

<!-- Observações, decisões técnicas, ou pontos de atenção para o reviewer -->
