### PR TITLE
fix: caminho errado do endpoint de captcha (users/captcha/new/, não c…

### DIFF
--- a/salonix-frontend-web/src/api/__tests__/captcha.test.js
+++ b/salonix-frontend-web/src/api/__tests__/captcha.test.js
@@ -17,8 +17,9 @@ describe('fetchCaptchaChallenge', () => {
     // the X-Requested-With: XMLHttpRequest header (which axios never sends),
     // always 404ing in real usage. Use our own endpoint instead, which
     // returns the same {key, image_url} shape and validates against the
-    // same CaptchaStore.
-    expect(client.get).toHaveBeenCalledWith('captcha/new/');
+    // same CaptchaStore. It's mounted under 'users/' (users/urls.py is
+    // included at 'api/users/' in the root urls.py), not 'captcha/'.
+    expect(client.get).toHaveBeenCalledWith('users/captcha/new/');
     expect(result).toEqual({
       key: 'abc123',
       image_url: '/api/captcha/image/abc123/',

--- a/salonix-frontend-web/src/api/captcha.js
+++ b/salonix-frontend-web/src/api/captcha.js
@@ -4,13 +4,15 @@ import client from './client';
  * Busca um novo desafio de captcha (key + URL da imagem) do backend.
  * Usado no registo público de clientes.
  *
- * Usa o endpoint próprio ('captcha/new/'), não o 'captcha/refresh/' do
- * django-simple-captcha — esse exige o header X-Requested-With:
+ * Usa o endpoint próprio ('users/captcha/new/'), não o 'captcha/refresh/'
+ * do django-simple-captcha — esse exige o header X-Requested-With:
  * XMLHttpRequest, que o axios não envia, o que faz o endpoint devolver
  * sempre 404. O endpoint próprio devolve a mesma forma de resposta
- * ({key, image_url}) e valida contra o mesmo CaptchaStore.
+ * ({key, image_url}) e valida contra o mesmo CaptchaStore. Está montado
+ * sob o prefixo 'users/' (users/urls.py incluído em 'api/users/' no
+ * urls.py principal) — não em 'captcha/' apesar do nome do módulo.
  */
 export async function fetchCaptchaChallenge() {
-  const { data } = await client.get('captcha/new/');
+  const { data } = await client.get('users/captcha/new/');
   return data;
 }


### PR DESCRIPTION
…aptcha/new/)

O fix anterior apontou para '/api/captcha/new/', mas CaptchaGenerateView está montado sob '/api/users/captcha/new/' (users.urls é incluído com prefixo 'api/users/' no urls.py principal). Confirmado em produção pelos logs do Railway (404 em /api/captcha/new/) e localmente via curl.

## Descrição

<!-- Descreva o que esta PR faz e por quê -->

Closes #

---

## Tipo de mudança

- [ ] Bug fix
- [ ] Nova feature
- [ ] Refactor
- [ ] Segurança
- [ ] Docs / config

---

## Checklist de Segurança FEW

Marque os itens relevantes para esta PR. Se o item não se aplica, marque N/A.

### Execução de Código
- [ ] Não há uso de `eval()`, `new Function()`, ou `setTimeout(string)`
- [ ] Não há uso de `dangerouslySetInnerHTML` sem sanitização (ex: DOMPurify)
- [ ] Não há construção de HTML por concatenação de strings

### Tokens e Dados Sensíveis
- [ ] Tokens não são expostos em query strings de URLs
- [ ] Tokens não aparecem em logs (`console.log`, telemetry events)
- [ ] Links com tokens usam header ou rid em vez de `?token=`
- [ ] Emails/SMS não contêm tokens diretos (usar rid com TTL)

### Redirecionamentos
- [ ] Redirecionamentos externos passam por `safeRedirect()` de `src/utils/safeRedirect`
- [ ] Links externos usam `rel="noreferrer"` ou `referrerPolicy: 'no-referrer'`
- [ ] Não há `window.location = userInput` sem validação

### Formulários e Inputs
- [ ] Inputs de usuário não são usados como seletores CSS ou caminhos de URL diretos
- [ ] Upload de arquivos valida tipo e tamanho antes de enviar
- [ ] Dados de formulário são enviados via HTTPS (fetch com URL relativa ou VITE_API_URL)

### Dependências Externas
- [ ] Scripts externos (captcha, analytics) não foram adicionados sem aprovação
- [ ] Não há chamadas para CDNs externos não aprovados
- [ ] N/A — nenhuma dependência externa nova

### Testes
- [ ] Testes existentes continuam passando (`npm test -- --no-coverage`)
- [ ] Cenários de segurança afetados têm cobertura de testes
- [ ] N/A — mudança não afeta fluxos de segurança

---

## Notas

<!-- Observações, decisões técnicas, ou pontos de atenção para o reviewer -->
