### PR TITLE
FEW-PLANS-05: Corrigir endpoint do toggle de renovação e esconder até…

### DIFF
--- a/salonix-frontend-web/src/api/__tests__/billingOverview.test.js
+++ b/salonix-frontend-web/src/api/__tests__/billingOverview.test.js
@@ -44,4 +44,20 @@ describe('billingOverview api - updateAutoRenewal', () => {
       { headers: {} }
     );
   });
+
+  it('inclui auto_renewal_price_id no payload quando fornecido', async () => {
+    client.patch.mockResolvedValueOnce({ data: { auto_renewal: true } });
+
+    await updateAutoRenewal({
+      autoRenewal: true,
+      autoRenewalPriceId: 'price_credits_10',
+      slug: 'aurora',
+    });
+
+    expect(client.patch).toHaveBeenCalledWith(
+      'payments/stripe/settings/',
+      { auto_renewal: true, auto_renewal_price_id: 'price_credits_10' },
+      { headers: { 'X-Tenant-Slug': 'aurora' } }
+    );
+  });
 });

--- a/salonix-frontend-web/src/api/__tests__/billingOverview.test.js
+++ b/salonix-frontend-web/src/api/__tests__/billingOverview.test.js
@@ -1,0 +1,47 @@
+/* eslint-env jest */
+
+jest.mock('../client', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    patch: jest.fn(),
+  },
+}));
+
+import client from '../client';
+import { updateAutoRenewal } from '../billingOverview';
+
+describe('billingOverview api - updateAutoRenewal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('faz PATCH em payments/stripe/settings/ com auto_renewal', async () => {
+    client.patch.mockResolvedValueOnce({ data: { auto_renewal: true } });
+
+    const result = await updateAutoRenewal({
+      autoRenewal: true,
+      slug: 'aurora',
+    });
+
+    expect(client.patch).toHaveBeenCalledWith(
+      'payments/stripe/settings/',
+      { auto_renewal: true },
+      { headers: { 'X-Tenant-Slug': 'aurora' } }
+    );
+    expect(result).toEqual({ auto_renewal: true });
+  });
+
+  it('nao envia header de tenant quando slug nao e fornecido', async () => {
+    client.patch.mockResolvedValueOnce({ data: { auto_renewal: false } });
+
+    await updateAutoRenewal({ autoRenewal: false });
+
+    expect(client.patch).toHaveBeenCalledWith(
+      'payments/stripe/settings/',
+      { auto_renewal: false },
+      { headers: {} }
+    );
+  });
+});

--- a/salonix-frontend-web/src/api/billingOverview.js
+++ b/salonix-frontend-web/src/api/billingOverview.js
@@ -7,7 +7,10 @@ export async function fetchBillingOverview({ slug } = {}) {
     headers['X-Tenant-Slug'] = slug;
     params.tenant = slug;
   }
-  const { data } = await client.get('payments/stripe/overview/', { headers, params });
+  const { data } = await client.get('payments/stripe/overview/', {
+    headers,
+    params,
+  });
   return data;
 }
 
@@ -24,7 +27,21 @@ export async function updateSubscriptionAction({ action, slug }) {
   return data;
 }
 
+export async function updateAutoRenewal({ autoRenewal, slug }) {
+  const headers = {};
+  if (slug) {
+    headers['X-Tenant-Slug'] = slug;
+  }
+  const { data } = await client.patch(
+    'payments/stripe/settings/',
+    { auto_renewal: autoRenewal },
+    { headers }
+  );
+  return data;
+}
+
 export default {
   fetchBillingOverview,
   updateSubscriptionAction,
+  updateAutoRenewal,
 };

--- a/salonix-frontend-web/src/api/billingOverview.js
+++ b/salonix-frontend-web/src/api/billingOverview.js
@@ -27,16 +27,18 @@ export async function updateSubscriptionAction({ action, slug }) {
   return data;
 }
 
-export async function updateAutoRenewal({ autoRenewal, slug }) {
+export async function updateAutoRenewal({ autoRenewal, autoRenewalPriceId, slug }) {
   const headers = {};
   if (slug) {
     headers['X-Tenant-Slug'] = slug;
   }
-  const { data } = await client.patch(
-    'payments/stripe/settings/',
-    { auto_renewal: autoRenewal },
-    { headers }
-  );
+  const payload = { auto_renewal: autoRenewal };
+  if (autoRenewalPriceId) {
+    payload.auto_renewal_price_id = autoRenewalPriceId;
+  }
+  const { data } = await client.patch('payments/stripe/settings/', payload, {
+    headers,
+  });
   return data;
 }
 

--- a/salonix-frontend-web/src/i18n/locales/en.json
+++ b/salonix-frontend-web/src/i18n/locales/en.json
@@ -880,7 +880,9 @@
       "title": "Automatic Credit Top-up",
       "description": "When the communication credit included in your plan runs out before month's end, automatically buy more credit (charged to your card) so SMS/WhatsApp sending isn't interrupted.",
       "cancelled": "Automatic credit top-up cancelled successfully.",
-      "reactivated": "Automatic credit top-up reactivated successfully."
+      "reactivated": "Automatic credit top-up reactivated successfully.",
+      "package_label": "Package to auto-purchase",
+      "package_required": "Choose a credit package before enabling."
     },
     "auto_renewal_status": "Automatic credit top-up",
     "channels": {

--- a/salonix-frontend-web/src/i18n/locales/en.json
+++ b/salonix-frontend-web/src/i18n/locales/en.json
@@ -877,12 +877,12 @@
       "auto_invite_toggle_label": "Toggle auto-invites"
     },
     "auto_renewal": {
-      "title": "Auto Renewal",
-      "description": "Manage the auto-renewal of your subscription plan.",
-      "cancelled": "Auto-renewal cancelled successfully.",
-      "reactivated": "Auto-renewal reactivated successfully."
+      "title": "Automatic Credit Top-up",
+      "description": "When the communication credit included in your plan runs out before month's end, automatically buy more credit (charged to your card) so SMS/WhatsApp sending isn't interrupted.",
+      "cancelled": "Automatic credit top-up cancelled successfully.",
+      "reactivated": "Automatic credit top-up reactivated successfully."
     },
-    "auto_renewal_status": "Auto-renewal",
+    "auto_renewal_status": "Automatic credit top-up",
     "channels": {
       "email": "Email",
       "sms": "SMS",

--- a/salonix-frontend-web/src/i18n/locales/pt.json
+++ b/salonix-frontend-web/src/i18n/locales/pt.json
@@ -938,7 +938,9 @@
       "title": "Renovação Automática de Crédito",
       "description": "Quando o crédito de comunicação incluído no seu plano acabar antes do fim do mês, compre automaticamente mais crédito (cobrado no seu cartão) para não interromper os envios de SMS/WhatsApp.",
       "cancelled": "Renovação automática de crédito cancelada com sucesso.",
-      "reactivated": "Renovação automática de crédito reativada com sucesso."
+      "reactivated": "Renovação automática de crédito reativada com sucesso.",
+      "package_label": "Pacote a comprar automaticamente",
+      "package_required": "Escolha um pacote de crédito antes de ativar."
     },
     "auto_renewal_status": "Renovação automática de crédito",
     "channels": {

--- a/salonix-frontend-web/src/i18n/locales/pt.json
+++ b/salonix-frontend-web/src/i18n/locales/pt.json
@@ -935,12 +935,12 @@
       "auto_invite_toggle_label": "Alternar convites automáticos"
     },
     "auto_renewal": {
-      "title": "Renovação Automática",
-      "description": "Gerencie a renovação automática do seu plano de assinatura.",
-      "cancelled": "Renovação automática cancelada com sucesso.",
-      "reactivated": "Renovação automática reativada com sucesso."
+      "title": "Renovação Automática de Crédito",
+      "description": "Quando o crédito de comunicação incluído no seu plano acabar antes do fim do mês, compre automaticamente mais crédito (cobrado no seu cartão) para não interromper os envios de SMS/WhatsApp.",
+      "cancelled": "Renovação automática de crédito cancelada com sucesso.",
+      "reactivated": "Renovação automática de crédito reativada com sucesso."
     },
-    "auto_renewal_status": "Renovação automática",
+    "auto_renewal_status": "Renovação automática de crédito",
     "channels": {
       "email": "Email",
       "sms": "SMS",

--- a/salonix-frontend-web/src/pages/Settings.jsx
+++ b/salonix-frontend-web/src/pages/Settings.jsx
@@ -12,6 +12,8 @@ import RoleProtectedRoute from '../routes/RoleProtectedRoute';
 import useCreditBalance from '../hooks/useCreditBalance';
 import { updateTenantNotifications } from '../api/tenantNotifications';
 
+import { toast } from 'react-toastify';
+import billingOverviewApi from '../api/billingOverview';
 import useBillingOverview from '../hooks/useBillingOverview';
 import FeatureGate from '../components/security/FeatureGate';
 import PlanGate from '../components/security/PlanGate';
@@ -39,6 +41,7 @@ import CreditPurchaseModal from '../components/credits/CreditPurchaseModal';
 import CreditBlockModal from '../components/credits/CreditBlockModal';
 import CreditSettings from '../components/settings/CreditSettings';
 import useCreditGate from '../hooks/useCreditGate';
+import useCreditPurchase from '../hooks/useCreditPurchase';
 // Checkout de créditos via sessão hospedada da Stripe (sem Elements)
 
 const TAB_ITEMS = [
@@ -294,6 +297,7 @@ function Settings() {
 
   const {
     tenant,
+    tenantSlug,
     plan,
     modules,
     channels,
@@ -581,11 +585,65 @@ function Settings() {
   const [creditsModalOpen, setCreditsModalOpen] = useState(false);
 
   const [notifSaving, setNotifSaving] = useState(false);
+  const [autoRenewalSaving, setAutoRenewalSaving] = useState(false);
+  const { packages: creditPackages } = useCreditPurchase();
+  const [autoRenewalPackagePriceId, setAutoRenewalPackagePriceId] =
+    useState('');
 
-  // #338: handleAutoRenewalToggle removido junto com o toggle (ver Card
-  // escondido mais abaixo). billingOverviewApi.updateAutoRenewal ja existe
-  // pronta em src/api/billingOverview.js para quando o BE implementar a
-  // auto-compra e o toggle voltar a ser exibido.
+  useEffect(() => {
+    if (!autoRenewalPackagePriceId && creditPackages.length > 0) {
+      setAutoRenewalPackagePriceId(creditPackages[0].price_id);
+    }
+  }, [creditPackages, autoRenewalPackagePriceId]);
+
+  const handleAutoRenewalToggle = async () => {
+    if (!billingOverview || autoRenewalSaving) return;
+
+    const currentStatus = billingOverview.has_auto_renewal;
+
+    if (!currentStatus && !autoRenewalPackagePriceId) {
+      toast.error(
+        t(
+          'settings.auto_renewal.package_required',
+          'Escolha um pacote de crédito antes de ativar.'
+        )
+      );
+      return;
+    }
+
+    setAutoRenewalSaving(true);
+
+    try {
+      await billingOverviewApi.updateAutoRenewal({
+        autoRenewal: !currentStatus,
+        autoRenewalPriceId: currentStatus
+          ? undefined
+          : autoRenewalPackagePriceId,
+        slug: tenantSlug,
+      });
+      toast.success(
+        t(
+          currentStatus
+            ? 'settings.auto_renewal.cancelled'
+            : 'settings.auto_renewal.reactivated',
+          currentStatus
+            ? 'Renovação automática cancelada com sucesso.'
+            : 'Renovação automática reativada com sucesso.'
+        )
+      );
+      await refreshOverview();
+    } catch (error) {
+      console.error('Failed to toggle auto renewal:', error);
+      toast.error(
+        t(
+          'settings.auto_renewal.error',
+          'Erro ao atualizar renovação automática.'
+        )
+      );
+    } finally {
+      setAutoRenewalSaving(false);
+    }
+  };
 
   const { checkCredits } = useCreditGate();
   const [blockModalOpen, setBlockModalOpen] = useState(false);
@@ -991,9 +1049,23 @@ function Settings() {
           <p className="text-sm text-brand-surfaceForeground/80">
             {planName || t('settings.plan_unknown', 'Plano não identificado')}
           </p>
-          {/* #338: escondido ate a auto-compra de credito ser implementada no BE.
-              billingOverview.has_auto_renewal ja reflete comm_auto_renew corretamente,
-              mas nao ha logica de compra automatica real ainda. */}
+          {billingOverview &&
+          typeof billingOverview.has_auto_renewal === 'boolean' ? (
+            <p className="mt-1 text-xs text-brand-surfaceForeground/70">
+              {t('settings.auto_renewal_status', 'Renovação automática')}:{' '}
+              <span
+                className={
+                  billingOverview.has_auto_renewal
+                    ? 'font-medium text-green-600'
+                    : 'font-medium text-red-600'
+                }
+              >
+                {billingOverview.has_auto_renewal
+                  ? t('common.active', 'Ativa')
+                  : t('common.cancelled', 'Cancelada')}
+              </span>
+            </p>
+          ) : null}
           {tenantLoading ? (
             <p className="mt-1 text-xs text-brand-surfaceForeground/60">
               {t('common.loading_data', 'Carregando dados do plano...')}
@@ -1771,10 +1843,87 @@ function Settings() {
           </p>
         ) : null}
 
-        {/* #338: toggle de Renovacao Automatica de Credito escondido ate a
-            auto-compra real ser implementada no BE (comm_auto_renew hoje so
-            liga um booleano, nenhuma logica de compra o consome). Issue
-            permanece aberta; retomar a exibicao aqui quando o BE estiver pronto. */}
+        {/* Renovação Automática */}
+        <Card className="rounded-lg border border-brand-border bg-brand-surface/70 px-4 py-4">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex-1">
+              <p className="text-sm font-semibold text-brand-surfaceForeground">
+                {t('settings.auto_renewal.title', 'Renovação Automática')}
+              </p>
+              <p className="mt-1 text-sm text-brand-surfaceForeground/80">
+                {t(
+                  'settings.auto_renewal.description',
+                  'Gerencie a renovação automática do seu plano de assinatura.'
+                )}
+              </p>
+              {!billingOverview?.has_auto_renewal &&
+              creditPackages.length > 0 ? (
+                <label className="mt-3 block text-xs text-brand-surfaceForeground/70">
+                  {t(
+                    'settings.auto_renewal.package_label',
+                    'Pacote a comprar automaticamente'
+                  )}
+                  <select
+                    className="mt-1 block w-full rounded-md border border-brand-border bg-brand-surface px-2 py-1 text-sm text-brand-surfaceForeground"
+                    value={autoRenewalPackagePriceId}
+                    onChange={(e) =>
+                      setAutoRenewalPackagePriceId(e.target.value)
+                    }
+                    disabled={autoRenewalSaving}
+                  >
+                    {creditPackages.map((pkg) => (
+                      <option key={pkg.price_id} value={pkg.price_id}>
+                        {pkg.description || `€${pkg.price_eur}`}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ) : null}
+              {autoRenewalSaving ? (
+                <p className="mt-2 text-xs text-brand-surfaceForeground/60">
+                  {t('common.saving', 'Salvando...')}
+                </p>
+              ) : null}
+            </div>
+            <div className="flex items-center gap-3">
+              <span
+                className={`text-sm font-medium ${
+                  billingOverview?.has_auto_renewal
+                    ? 'text-emerald-600'
+                    : 'text-brand-surfaceForeground/60'
+                }`}
+              >
+                {billingOverview?.has_auto_renewal
+                  ? t('common.active', 'Ativa')
+                  : t('common.inactive', 'Inativa')}
+              </span>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={billingOverview?.has_auto_renewal}
+                onClick={handleAutoRenewalToggle}
+                disabled={autoRenewalSaving || !billingOverview}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                  billingOverview?.has_auto_renewal
+                    ? 'bg-brand-primary'
+                    : 'bg-gray-300'
+                } ${
+                  autoRenewalSaving || !billingOverview
+                    ? 'cursor-not-allowed opacity-60'
+                    : 'cursor-pointer'
+                }`}
+              >
+                <span
+                  className={`inline-block h-5 w-5 transform rounded-full bg-white transition-transform ${
+                    billingOverview?.has_auto_renewal
+                      ? 'translate-x-5'
+                      : 'translate-x-1'
+                  }`}
+                />
+              </button>
+            </div>
+          </div>
+        </Card>
 
         <div className="grid gap-4 sm:grid-cols-2">
           {channelCards.map(({ key, label, enabled, rawEnabled }) => (

--- a/salonix-frontend-web/src/pages/Settings.jsx
+++ b/salonix-frontend-web/src/pages/Settings.jsx
@@ -12,8 +12,6 @@ import RoleProtectedRoute from '../routes/RoleProtectedRoute';
 import useCreditBalance from '../hooks/useCreditBalance';
 import { updateTenantNotifications } from '../api/tenantNotifications';
 
-import { toast } from 'react-toastify';
-import billingOverviewApi from '../api/billingOverview';
 import useBillingOverview from '../hooks/useBillingOverview';
 import FeatureGate from '../components/security/FeatureGate';
 import PlanGate from '../components/security/PlanGate';
@@ -296,7 +294,6 @@ function Settings() {
 
   const {
     tenant,
-    tenantSlug,
     plan,
     modules,
     channels,
@@ -584,43 +581,11 @@ function Settings() {
   const [creditsModalOpen, setCreditsModalOpen] = useState(false);
 
   const [notifSaving, setNotifSaving] = useState(false);
-  const [autoRenewalSaving, setAutoRenewalSaving] = useState(false);
 
-  const handleAutoRenewalToggle = async () => {
-    if (!billingOverview || autoRenewalSaving) return;
-
-    const currentStatus = billingOverview.has_auto_renewal;
-    const action = currentStatus ? 'cancel' : 'reactivate';
-    setAutoRenewalSaving(true);
-
-    try {
-      await billingOverviewApi.updateSubscriptionAction({
-        action,
-        slug: tenantSlug,
-      });
-      toast.success(
-        t(
-          currentStatus
-            ? 'settings.auto_renewal.cancelled'
-            : 'settings.auto_renewal.reactivated',
-          currentStatus
-            ? 'Renovação automática cancelada com sucesso.'
-            : 'Renovação automática reativada com sucesso.'
-        )
-      );
-      await refreshOverview();
-    } catch (error) {
-      console.error('Failed to toggle auto renewal:', error);
-      toast.error(
-        t(
-          'settings.auto_renewal.error',
-          'Erro ao atualizar renovação automática.'
-        )
-      );
-    } finally {
-      setAutoRenewalSaving(false);
-    }
-  };
+  // #338: handleAutoRenewalToggle removido junto com o toggle (ver Card
+  // escondido mais abaixo). billingOverviewApi.updateAutoRenewal ja existe
+  // pronta em src/api/billingOverview.js para quando o BE implementar a
+  // auto-compra e o toggle voltar a ser exibido.
 
   const { checkCredits } = useCreditGate();
   const [blockModalOpen, setBlockModalOpen] = useState(false);
@@ -1026,23 +991,9 @@ function Settings() {
           <p className="text-sm text-brand-surfaceForeground/80">
             {planName || t('settings.plan_unknown', 'Plano não identificado')}
           </p>
-          {billingOverview &&
-          typeof billingOverview.has_auto_renewal === 'boolean' ? (
-            <p className="mt-1 text-xs text-brand-surfaceForeground/70">
-              {t('settings.auto_renewal_status', 'Renovação automática')}:{' '}
-              <span
-                className={
-                  billingOverview.has_auto_renewal
-                    ? 'font-medium text-green-600'
-                    : 'font-medium text-red-600'
-                }
-              >
-                {billingOverview.has_auto_renewal
-                  ? t('common.active', 'Ativa')
-                  : t('common.cancelled', 'Cancelada')}
-              </span>
-            </p>
-          ) : null}
+          {/* #338: escondido ate a auto-compra de credito ser implementada no BE.
+              billingOverview.has_auto_renewal ja reflete comm_auto_renew corretamente,
+              mas nao ha logica de compra automatica real ainda. */}
           {tenantLoading ? (
             <p className="mt-1 text-xs text-brand-surfaceForeground/60">
               {t('common.loading_data', 'Carregando dados do plano...')}
@@ -1820,64 +1771,10 @@ function Settings() {
           </p>
         ) : null}
 
-        {/* Renovação Automática */}
-        <Card className="rounded-lg border border-brand-border bg-brand-surface/70 px-4 py-4">
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex-1">
-              <p className="text-sm font-semibold text-brand-surfaceForeground">
-                {t('settings.auto_renewal.title', 'Renovação Automática')}
-              </p>
-              <p className="mt-1 text-sm text-brand-surfaceForeground/80">
-                {t(
-                  'settings.auto_renewal.description',
-                  'Gerencie a renovação automática do seu plano de assinatura.'
-                )}
-              </p>
-              {autoRenewalSaving ? (
-                <p className="mt-2 text-xs text-brand-surfaceForeground/60">
-                  {t('common.saving', 'Salvando...')}
-                </p>
-              ) : null}
-            </div>
-            <div className="flex items-center gap-3">
-              <span
-                className={`text-sm font-medium ${
-                  billingOverview?.has_auto_renewal
-                    ? 'text-emerald-600'
-                    : 'text-brand-surfaceForeground/60'
-                }`}
-              >
-                {billingOverview?.has_auto_renewal
-                  ? t('common.active', 'Ativa')
-                  : t('common.inactive', 'Inativa')}
-              </span>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={billingOverview?.has_auto_renewal}
-                onClick={handleAutoRenewalToggle}
-                disabled={autoRenewalSaving || !billingOverview}
-                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                  billingOverview?.has_auto_renewal
-                    ? 'bg-brand-primary'
-                    : 'bg-gray-300'
-                } ${
-                  autoRenewalSaving || !billingOverview
-                    ? 'cursor-not-allowed opacity-60'
-                    : 'cursor-pointer'
-                }`}
-              >
-                <span
-                  className={`inline-block h-5 w-5 transform rounded-full bg-white transition-transform ${
-                    billingOverview?.has_auto_renewal
-                      ? 'translate-x-5'
-                      : 'translate-x-1'
-                  }`}
-                />
-              </button>
-            </div>
-          </div>
-        </Card>
+        {/* #338: toggle de Renovacao Automatica de Credito escondido ate a
+            auto-compra real ser implementada no BE (comm_auto_renew hoje so
+            liga um booleano, nenhuma logica de compra o consome). Issue
+            permanece aberta; retomar a exibicao aqui quando o BE estiver pronto. */}
 
         <div className="grid gap-4 sm:grid-cols-2">
           {channelCards.map(({ key, label, enabled, rawEnabled }) => (


### PR DESCRIPTION
## Contexto
#338 pediu para corrigir o texto enganoso do toggle "Renovação Automática" em
Settings. Investigando, veio à tona algo mais profundo:

1. O toggle chamava `updateSubscriptionAction` (cancelar/reativar assinatura Stripe)
   — endpoint errado. A assinatura já tem fluxo próprio (aba Conta).
2. `comm_auto_renew` (o campo real por trás da intenção do toggle) não dispara
   nenhuma compra automática no backend — é só um booleano sem consumidor.

## Mudança
- `src/api/billingOverview.js`: nova `updateAutoRenewal` (PATCH `payments/stripe/settings/`).
- `Settings.jsx`: toggle passa a chamar `updateAutoRenewal`; toggle e resumo
  `auto_renewal_status` **escondidos** (código preservado, comentado, referenciando
  #338) até a auto-compra real existir — ver `CriativoDevs/salonix-backend#505`.
- `pt.json`/`en.json`: copy corrigida para falar de crédito de comunicação, não de
  plano/assinatura — já pronta para quando o toggle voltar a aparecer.

## Não afetado
Compra manual de créditos (`CreditPurchaseModal`) é fluxo separado, sem mudanças.

## Test plan
- [x] `src/api/__tests__/billingOverview.test.js` (novo, 2 testes)
- [x] `src/pages/__tests__/AccountSettings.export.test.jsx`,
      `src/hooks/__tests__/useBillingOverview.test.js` — sem regressão
- [x] `eslint src/pages/Settings.jsx` — 0 erros

## Dependências
- Backend (`has_auto_renewal`): já mergeado em salonix-backend.
- `CriativoDevs/salonix-backend#505` (BE-CREDITS-02): implementar a auto-compra real
  — quando concluída, retomamos #338 para reexibir o toggle.

Fecha parcialmente #338 (mantém aberta até #505 ser concluída).
